### PR TITLE
CMP0175 Fix

### DIFF
--- a/cmake/bgfx/examples.cmake
+++ b/cmake/bgfx/examples.cmake
@@ -169,38 +169,44 @@ function(add_example ARG_NAME)
 				# on iOS we need to build a bundle so have to copy the data rather than symlink
 				# and on windows we can't create symlinks
 				add_custom_command(
-					TARGET example-${ARG_NAME} COMMAND ${CMAKE_COMMAND} -E copy_directory ${BGFX_DIR}/examples/runtime/
+					TARGET example-${ARG_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${BGFX_DIR}/examples/runtime/
 													   $<TARGET_FILE_DIR:example-${ARG_NAME}>
 				)
 			else()
 				# For everything else symlink some folders into our output directory
 				add_custom_command(
 					TARGET example-${ARG_NAME}
+					POST_BUILD
 					COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/font
 							$<TARGET_FILE_DIR:example-${ARG_NAME}>/font
 				)
 				add_custom_command(
 					TARGET example-${ARG_NAME}
+					POST_BUILD
 					COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/images
 							$<TARGET_FILE_DIR:example-${ARG_NAME}>/images
 				)
 				add_custom_command(
 					TARGET example-${ARG_NAME}
+					POST_BUILD
 					COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/meshes
 							$<TARGET_FILE_DIR:example-${ARG_NAME}>/meshes
 				)
 				add_custom_command(
 					TARGET example-${ARG_NAME}
+					POST_BUILD
 					COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/shaders
 							$<TARGET_FILE_DIR:example-${ARG_NAME}>/shaders
 				)
 				add_custom_command(
 					TARGET example-${ARG_NAME}
+					POST_BUILD
 					COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/text
 							$<TARGET_FILE_DIR:example-${ARG_NAME}>/text
 				)
 				add_custom_command(
 					TARGET example-${ARG_NAME}
+					POST_BUILD
 					COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/textures
 							$<TARGET_FILE_DIR:example-${ARG_NAME}>/textures
 				)


### PR DESCRIPTION
Simple fix for cmake policy CMP0175. Just adding POST_BUILD to example runtime things. Silences the CMP0175 warning. I think POST_BUILD was the default behavior before. CMake doesn't complain about 175 and the examples still build correctly for me.