### PR TITLE
update shaderc target profiles

### DIFF
--- a/cmake/bgfx/shaderc.cmake
+++ b/cmake/bgfx/shaderc.cmake
@@ -39,6 +39,7 @@ target_include_directories(
 			${BGFX_DIR}/3rdparty/dawn/src
 )
 
+set(DXCOMPILER_RUNTIME)
 if(UNIX
    AND NOT APPLE
    AND NOT EMSCRIPTEN
@@ -50,6 +51,9 @@ if(UNIX
 				${BGFX_DIR}/3rdparty/directx-headers/include
 				${BGFX_DIR}/3rdparty/directx-headers/include/wsl/stubs
 	)
+	set(DXCOMPILER_RUNTIME ${BGFX_DIR}/tools/bin/linux/libdxcompiler.so)
+elseif(WIN32)
+	set(DXCOMPILER_RUNTIME ${BGFX_DIR}/tools/bin/windows/dxcompiler.dll)
 endif()
 
 if(BGFX_AMALGAMATED)
@@ -76,4 +80,16 @@ endif()
 
 if(BGFX_INSTALL)
 	install(TARGETS shaderc EXPORT "${TARGETS_EXPORT_NAME}" DESTINATION "${CMAKE_INSTALL_BINDIR}")
+endif()
+
+# DXIL compiler will be dynamically loaded at runtime - no need
+# to link, just install the needed binaries alongside shaderc.exe
+if(DXCOMPILER_RUNTIME)
+	add_custom_command(
+		TARGET shaderc POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${DXCOMPILER_RUNTIME} $<TARGET_FILE_DIR:shaderc>
+	)
+	if(BGFX_INSTALL)
+		install(FILES ${DXCOMPILER_RUNTIME} DESTINATION "${CMAKE_INSTALL_BINDIR}")
+	endif()
 endif()

--- a/cmake/bgfxToolUtils.cmake
+++ b/cmake/bgfxToolUtils.cmake
@@ -535,21 +535,25 @@ if(TARGET bgfx::shaderc)
 
 	# extensions consistent with those listed under bgfx/runtime/shaders
 	function(_bgfx_get_profile_path_ext PROFILE PROFILE_PATH_EXT)
+		string(REPLACE 100_es essl PROFILE ${PROFILE})
 		string(REPLACE 300_es essl PROFILE ${PROFILE})
 		string(REPLACE 120 glsl PROFILE ${PROFILE})
-		string(REPLACE s_4_0 dx10 PROFILE ${PROFILE})
-		string(REPLACE s_5_0 dx11 PROFILE ${PROFILE})
+		string(REPLACE 430 glsl PROFILE ${PROFILE})
+		string(REPLACE s_5_0 dxbc PROFILE ${PROFILE})
+		string(REPLACE s_6_0 dxil PROFILE ${PROFILE})
 		set(${PROFILE_PATH_EXT} ${PROFILE} PARENT_SCOPE)
 	endfunction()
 
 	# extensions consistent with embedded_shader.h
 	function(_bgfx_get_profile_ext PROFILE PROFILE_EXT)
+		string(REPLACE 100_es essl PROFILE ${PROFILE})
 		string(REPLACE 300_es essl PROFILE ${PROFILE})
 		string(REPLACE 120 glsl PROFILE ${PROFILE})
+		string(REPLACE 430 glsl PROFILE ${PROFILE})
 		string(REPLACE spirv spv PROFILE ${PROFILE})
 		string(REPLACE metal mtl PROFILE ${PROFILE})
-		string(REPLACE s_4_0 dx10 PROFILE ${PROFILE})
-		string(REPLACE s_5_0 dx11 PROFILE ${PROFILE})
+		string(REPLACE s_5_0 dxbc PROFILE ${PROFILE})
+		string(REPLACE s_6_0 dxil PROFILE ${PROFILE})
 		set(${PROFILE_EXT} ${PROFILE} PARENT_SCOPE)
 	endfunction()
 
@@ -570,7 +574,15 @@ if(TARGET bgfx::shaderc)
 		set(multiValueArgs SHADERS INCLUDE_DIRS DEFINES)
 		cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
 
-		set(PROFILES 120 300_es spirv)
+		set(PROFILES spirv)
+		if(ARGS_TYPE STREQUAL "COMPUTE")
+			list(APPEND PROFILES 430 300_es)
+		else()
+			list(APPEND PROFILES 120 100_es)
+		endif()
+		if(BGFX_CONFIG_RENDERER_WEBGPU)
+			list(APPEND PROFILES wgsl)
+		endif()
 		if(IOS)
 			set(PLATFORM IOS)
 			list(APPEND PROFILES metal)
@@ -590,8 +602,8 @@ if(TARGET bgfx::shaderc)
 			OR CYGWIN
 		)
 			set(PLATFORM WINDOWS)
-			list(APPEND PROFILES s_4_0)
 			list(APPEND PROFILES s_5_0)
+			list(APPEND PROFILES s_6_0)
 		elseif(ORBIS) # ORBIS should be defined by a PS4 CMake toolchain
 			set(PLATFORM ORBIS)
 			list(APPEND PROFILES pssl)
@@ -620,9 +632,6 @@ if(TARGET bgfx::shaderc)
 				endif()
 				set(OUTPUT ${ARGS_OUTPUT_DIR}/${PROFILE_PATH_EXT}/${SHADER_FILE_BASENAME}.bin${HEADER_PREFIX})
 				set(PLATFORM_I ${PLATFORM})
-				if(PROFILE STREQUAL "spirv")
-					set(PLATFORM_I LINUX)
-				endif()
 				set(BIN2C_PART "")
 				if(ARGS_AS_HEADERS)
 					set(BIN2C_PART BIN2C ${SHADER_FILE_NAME_WE}_${PROFILE_EXT})
@@ -630,11 +639,11 @@ if(TARGET bgfx::shaderc)
 				_bgfx_shaderc_parse(
 					CLI #
 					${BIN2C_PART} #
-					${ARGS_TYPE} ${PLATFORM_I} WERROR "$<$<CONFIG:debug>:DEBUG>$<$<CONFIG:relwithdebinfo>:DEBUG>"
+					${ARGS_TYPE} ${PLATFORM_I} WERROR "$<$<CONFIG:Debug,RelWithDebInfo>:DEBUG>"
 					FILE ${SHADER_FILE_ABSOLUTE}
 					OUTPUT ${OUTPUT}
 					PROFILE ${PROFILE}
-					O "$<$<CONFIG:debug>:0>$<$<CONFIG:release>:3>$<$<CONFIG:relwithdebinfo>:3>$<$<CONFIG:minsizerel>:3>"
+					O "$<IF:$<CONFIG:Debug>:0,3>"
 					VARYINGDEF ${ARGS_VARYING_DEF}
 					INCLUDES ${BGFX_SHADER_INCLUDE_PATH} ${ARGS_INCLUDE_DIRS}
 					DEFINES ${ARGS_DEFINES}


### PR DESCRIPTION
Updating `shaderc` target profiles to match [upstream](https://github.com/bkaradzic/bgfx/blob/20a637e3e6dd946031dd21e74c7138d2fab06abc/scripts/shader-embeded.mk):
- dx10 is deprecated
- dx11 -> dxbc
- use appropriate gl target based on shader type
- add wgsl
- add dxil (dx12)

DXIL is a bit of an odd one as bgfx dynamically loads the compiler runtime from the shaderc binary path, so I've added some extra configuration to copy the appropriate vendored binaries over to the build output/install directories - might need a bit of testing outside of Windows incase CMake doesn't like targets without valid artifacts.

This does require a minor CMake version bump for [`install(IMPORTED_RUNTIME_ARTIFACTS)`](https://cmake.org/cmake/help/latest/command/install.html#imported-runtime-artifacts).