### PR TITLE
Fix all renderers defaulting to disabled

### DIFF
--- a/cmake/bgfx/bgfx.cmake
+++ b/cmake/bgfx/bgfx.cmake
@@ -64,8 +64,6 @@ if(BGFX_CONFIG_RENDERER_WEBGPU)
 	else()
 		target_link_libraries(bgfx PRIVATE webgpu)
 	endif()
-else()
-	target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_RENDERER_WEBGPU=0)
 endif()
 
 if(EMSCRIPTEN)


### PR DESCRIPTION
Caused by bkaradzic/bgfx.cmake#22

Overriding *any* renderer config defines causes bgfx to disable automatic config derivation for *all* renderers - this meant that force disabling WebGPU was also implicitly disabling all other renderers by default:
https://github.com/bkaradzic/bgfx/blob/0b1c1ecaca917acc093f755bf8468711a5b24aee/src/config.h#L22-L31

Not sure what the best option is here (outside of explicitly setting all renderers in the build system) but removing this for now to restore expected per-platform defaults.

Hopefully fixes bkaradzic/bgfx.cmake#25