### PR TITLE
Fix missing include in Linux 'd3d4linux.h' for shaderc

### DIFF
--- a/cmake/bgfx/shaderc.cmake
+++ b/cmake/bgfx/shaderc.cmake
@@ -49,6 +49,7 @@ if(UNIX
 		PRIVATE ${BGFX_DIR}/3rdparty/directx-headers/include/directx
 				${BGFX_DIR}/3rdparty/directx-headers/include
 				${BGFX_DIR}/3rdparty/directx-headers/include/wsl/stubs
+				${BGFX_DIR}/3rdparty/d3d4linux/include
 	)
 endif()
 

--- a/cmake/bgfx/shaderc.cmake
+++ b/cmake/bgfx/shaderc.cmake
@@ -50,6 +50,7 @@ if(UNIX
 		PRIVATE ${BGFX_DIR}/3rdparty/directx-headers/include/directx
 				${BGFX_DIR}/3rdparty/directx-headers/include
 				${BGFX_DIR}/3rdparty/directx-headers/include/wsl/stubs
+				${BGFX_DIR}/3rdparty/d3d4linux/include
 	)
 	set(DXCOMPILER_RUNTIME ${BGFX_DIR}/tools/bin/linux/libdxcompiler.so)
 elseif(WIN32)


### PR DESCRIPTION
When compiling shaderc on linux as a dependency the `shaderc_hlsl.cpp` includes `d3d4linux.h` which wasn't added as target include in the shaderc.cmake file... just adding the include directory allows shaderc to compile