### PR TITLE
Add PROFILES override to bgfx_compile_shaders

### DIFF
--- a/cmake/bgfxToolUtils.cmake
+++ b/cmake/bgfxToolUtils.cmake
@@ -565,27 +565,34 @@ if(TARGET bgfx::shaderc)
 	# 	OUT_FILES_VAR variable name
 	# 	INCLUDE_DIRS directories
 	# 	DEFINES defines
+	# 	[PROFILES profiles]
 	# 	[AS_HEADERS]
 	# )
 	#
 	function(bgfx_compile_shaders)
 		set(options AS_HEADERS)
 		set(oneValueArgs TYPE VARYING_DEF OUTPUT_DIR OUT_FILES_VAR)
-		set(multiValueArgs SHADERS INCLUDE_DIRS DEFINES)
+		set(multiValueArgs SHADERS INCLUDE_DIRS DEFINES PROFILES)
 		cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
 
-		set(PROFILES spirv)
-		if(ARGS_TYPE STREQUAL "COMPUTE")
-			list(APPEND PROFILES 430 300_es)
+		if(ARGS_PROFILES)
+			set(PROFILES ${ARGS_PROFILES})
 		else()
-			list(APPEND PROFILES 120 100_es)
-		endif()
-		if(BGFX_CONFIG_RENDERER_WEBGPU)
-			list(APPEND PROFILES wgsl)
+			set(PROFILES spirv)
+			if(ARGS_TYPE STREQUAL "COMPUTE")
+				list(APPEND PROFILES 430 300_es)
+			else()
+				list(APPEND PROFILES 120 100_es)
+			endif()
+			if(BGFX_CONFIG_RENDERER_WEBGPU)
+				list(APPEND PROFILES wgsl)
+			endif()
 		endif()
 		if(IOS)
 			set(PLATFORM IOS)
-			list(APPEND PROFILES metal)
+			if(NOT ARGS_PROFILES)
+				list(APPEND PROFILES metal)
+			endif()
 		elseif(ANDROID)
 			set(PLATFORM ANDROID)
 		elseif(UNIX AND NOT APPLE)
@@ -594,7 +601,9 @@ if(TARGET bgfx::shaderc)
 			set(PLATFORM ASM_JS)
 		elseif(APPLE)
 			set(PLATFORM OSX)
-			list(APPEND PROFILES metal)
+			if(NOT ARGS_PROFILES)
+				list(APPEND PROFILES metal)
+			endif()
 		elseif(
 			WIN32
 			OR MINGW
@@ -602,11 +611,14 @@ if(TARGET bgfx::shaderc)
 			OR CYGWIN
 		)
 			set(PLATFORM WINDOWS)
-			list(APPEND PROFILES s_5_0)
-			list(APPEND PROFILES s_6_0)
+			if(NOT ARGS_PROFILES)
+				list(APPEND PROFILES s_5_0 s_6_0)
+			endif()
 		elseif(ORBIS) # ORBIS should be defined by a PS4 CMake toolchain
 			set(PLATFORM ORBIS)
-			list(APPEND PROFILES pssl)
+			if(NOT ARGS_PROFILES)
+				list(APPEND PROFILES pssl)
+			endif()
 		else()
 			# pssl for Agc and Gnm renderers
 			# nvn for Nvn renderer


### PR DESCRIPTION
`bgfx_compile_shaders` uses a hardcoded set of shader profiles (e.g. 120/430 for GLSL), making it impossible to target custom profile versions.

This PR adds an optional `PROFILES` multi-value argument. When provided, it replaces the auto-detected profile list, giving the caller full control. When omitted, behavior is identical to before and fully backwards compatible.

Example use case  targeting GLSL 140 instead of 120:

```
bgfx_compile_shaders(
    TYPE VERTEX
    SHADERS my_shader.sc
    VARYING_DEF varying.def.sc
    OUTPUT_DIR ${CMAKE_BINARY_DIR}/shaders
    PROFILES spirv 140
)
```