### PR TITLE
Rename custom targets `tools` and `examples` to `bgfx-tools` and `bgfx-examples`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       # Build the examples which are excluded from all
       - name: Build examples
         run: |
-          cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target examples
+          cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target bgfx-examples
 
   cross-android:
     name: cross-android
@@ -122,4 +122,4 @@ jobs:
       # Build the examples which are excluded from all
       - name: Build examples
         run: |
-          cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target examples
+          cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target bgfx-examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,8 @@ file(TO_CMAKE_PATH "${BGFX_DIR}" BGFX_DIR)
 # sets project version from api ver / git rev
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.cmake)
 if(BGFX_BUILD_TOOLS AND BGFX_CUSTOM_TARGETS)
-	add_custom_target(tools)
-	set_target_properties(tools PROPERTIES FOLDER "bgfx/tools")
+	add_custom_target(bgfx-tools)
+	set_target_properties(bgfx-tools PROPERTIES FOLDER "bgfx/tools")
 endif()
 
 if(BGFX_INSTALL)

--- a/cmake/bgfx/examples.cmake
+++ b/cmake/bgfx/examples.cmake
@@ -228,7 +228,7 @@ function(add_example ARG_NAME)
 			set_target_properties(example-${ARG_NAME} PROPERTIES LINK_FLAGS "/ENTRY:\"mainCRTStartup\"")
 		endif()
 		if(BGFX_CUSTOM_TARGETS)
-			add_dependencies(examples example-${ARG_NAME})
+			add_dependencies(bgfx-examples example-${ARG_NAME})
 		endif()
 		if(IOS)
 			set_target_properties(
@@ -275,8 +275,8 @@ endfunction()
 
 # Build all examples target
 if(BGFX_CUSTOM_TARGETS)
-	add_custom_target(examples)
-	set_target_properties(examples PROPERTIES FOLDER "bgfx/examples")
+	add_custom_target(bgfx-examples)
+	set_target_properties(bgfx-examples PROPERTIES FOLDER "bgfx/examples")
 endif()
 
 # Add common library for examples

--- a/cmake/bgfx/geometryc.cmake
+++ b/cmake/bgfx/geometryc.cmake
@@ -30,7 +30,7 @@ set_target_properties(
 if(BGFX_BUILD_TOOLS_GEOMETRY)
 	add_executable(bgfx::geometryc ALIAS geometryc)
 	if(BGFX_CUSTOM_TARGETS)
-		add_dependencies(tools geometryc)
+		add_dependencies(bgfx-tools geometryc)
 	endif()
 endif()
 

--- a/cmake/bgfx/geometryv.cmake
+++ b/cmake/bgfx/geometryv.cmake
@@ -26,7 +26,7 @@ set_target_properties(
 )
 
 if(BGFX_BUILD_TOOLS_GEOMETRY AND BGFX_CUSTOM_TARGETS)
-	add_dependencies(tools geometryv)
+	add_dependencies(bgfx-tools geometryv)
 endif()
 
 if(ANDROID)

--- a/cmake/bgfx/shaderc.cmake
+++ b/cmake/bgfx/shaderc.cmake
@@ -68,7 +68,7 @@ set_target_properties(
 if(BGFX_BUILD_TOOLS_SHADER)
 	add_executable(bgfx::shaderc ALIAS shaderc)
 	if(BGFX_CUSTOM_TARGETS)
-		add_dependencies(tools shaderc)
+		add_dependencies(bgfx-tools shaderc)
 	endif()
 endif()
 

--- a/cmake/bgfx/texturev.cmake
+++ b/cmake/bgfx/texturev.cmake
@@ -26,7 +26,7 @@ set_target_properties(
 )
 
 if(BGFX_BUILD_TOOLS_TEXTURE AND BGFX_CUSTOM_TARGETS)
-	add_dependencies(tools texturev)
+	add_dependencies(bgfx-tools texturev)
 endif()
 
 if(ANDROID)

--- a/cmake/bimg/texturec.cmake
+++ b/cmake/bimg/texturec.cmake
@@ -25,7 +25,7 @@ set_target_properties(
 if(BGFX_BUILD_TOOLS_TEXTURE)
 	add_executable(bgfx::texturec ALIAS texturec)
 	if(BGFX_CUSTOM_TARGETS)
-		add_dependencies(tools texturec)
+		add_dependencies(bgfx-tools texturec)
 	endif()
 endif()
 

--- a/cmake/bx/bin2c.cmake
+++ b/cmake/bx/bin2c.cmake
@@ -25,7 +25,7 @@ set_target_properties(
 if(BGFX_BUILD_TOOLS_BIN2C)
 	add_executable(bgfx::bin2c ALIAS bin2c)
 	if(BGFX_CUSTOM_TARGETS)
-		add_dependencies(tools bin2c)
+		add_dependencies(bgfx-tools bin2c)
 	endif()
 endif()
 


### PR DESCRIPTION
CMake target names are globally scoped within a build system. When `bgfx.cmake` is consumed as a subdirectory via `add_subdirectory()` or `FetchContent,` the generic aggregate targets `tools` and `examples` can collide with same-name targets defined in the parent project or other dependencies, causing a CMake configuration error.

This change renames those two custom targets to `bgfx-tools` and `bgfx-examples` to avoid such conflicts, following the common convention of prefixing project-specific targets with the project name.

Changes:

- `tools` renamed to `bgfx-tools` 
- `examples` renamed to `bgfx-examples`

Notes:

- Only the aggregate grouping targets are renamed; all actual tool and example targets (`shaderc`, `geometryc`, `geometryv`, etc.) are unaffected.
- Both targets are already gated behind the `BGFX_CUSTOM_TARGETS` option, limiting the impact surface.
- This is a breaking change for anyone invoking `cmake --build . --target tools` or `cmake --build . --target examples` directly (e.g. in CI scripts). Those calls should be updated to use the new names.