### PR TITLE
cmake: rework sse4.2 detection for bx

### DIFF
--- a/cmake/bx/bx.cmake
+++ b/cmake/bx/bx.cmake
@@ -101,8 +101,8 @@ target_compile_options(bx PUBLIC $<$<CXX_COMPILER_ID:MSVC>:/Zc:__cplusplus /Zc:p
 
 # bx/include/bx/simd_t.h states the x86 minspec is SSE4.2 (smmintrin.h is included unconditionally),
 # matching bx/scripts/toolchain.lua which passes -msse4.2 on linux-gcc/clang and mingw.
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64|i.86|x86)$")
-	target_compile_options(bx PUBLIC $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-msse4.2>)
+if(MINGW OR (UNIX AND NOT APPLE AND NOT ANDROID))
+	target_compile_options(bx PUBLIC -msse4.2)
 endif()
 
 # Link against psapi on Windows


### PR DESCRIPTION
Compilations using msys / mingw were failing, ie

`MSYSTEM=UCRT64 /c/msys64/usr/bin/bash.exe -l -c 'cmake ...'`

```
In file included from D:/a/vpinball/vpinball/external/windows-x64-mingw/Release/bgfx/bgfx.cmake/bx/include/bx/simd_t.h:77,
                 from D:/a/vpinball/vpinball/external/windows-x64-mingw/Release/bgfx/bgfx.cmake/bx/include/bx/inline/math.inl:12,
                 from D:/a/vpinball/vpinball/external/windows-x64-mingw/Release/bgfx/bgfx.cmake/bx/include/bx/math.h:1827,
                 from D:/a/vpinball/vpinball/external/windows-x64-mingw/Release/bgfx/bgfx.cmake/bx/include/bx/readerwriter.h:13,
                 from D:/a/vpinball/vpinball/external/windows-x64-mingw/Release/bgfx/bgfx.cmake/bimg/src/bimg_p.h:46,
                 from D:/a/vpinball/vpinball/external/windows-x64-mingw/Release/bgfx/bgfx.cmake/bimg/src/image.cpp:6:
C:/msys64/ucrt64/lib/gcc/x86_64-w64-mingw32/15.2.0/include/smmintrin.h: In function 'Ty bx::simd128_f32_round(Ty) [with Ty = __vector(4) float]':
C:/msys64/ucrt64/lib/gcc/x86_64-w64-mingw32/15.2.0/include/smmintrin.h:125:1: error: inlining failed in call to 'always_inline' '__m128 _mm_round_ps(__m128, int)': target specific option mismatch
  125 | _mm_round_ps (__m128 __V, const int __M)
      | ^~~~~~~~~~~~
In file included from D:/a/vpinball/vpinball/external/windows-x64-mingw/Release/bgfx/bgfx.cmake/bx/include/bx/inline/simd_impl.inl:1302,
                 from D:/a/vpinball/vpinball/external/windows-x64-mingw/Release/bgfx/bgfx.cmake/bx/include/bx/simd_t.h:1530:
D:/a/vpinball/vpinball/external/windows-x64-mingw/Release/bgfx/bgfx.cmake/bx/include/bx/inline/simd128_sse.inl:296:36: note: called from here
  296 |                 return _mm_round_ps(_a, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
      |                        ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
