### PR TITLE
Fix unused argument warning during compilation on macOS ARM64

### DIFF
--- a/cmake/bx/bx.cmake
+++ b/cmake/bx/bx.cmake
@@ -100,10 +100,8 @@ target_compile_features(bx PUBLIC cxx_std_14)
 target_compile_options(bx PUBLIC $<$<CXX_COMPILER_ID:MSVC>:/Zc:__cplusplus /Zc:preprocessor>)
 
 # bx/include/bx/simd_t.h includes smmintrin.h unconditionally, so x86/x64 builds need SSE4.2.
-include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag(-msse4.2 BX_HAS_MSSE42)
-if(BX_HAS_MSSE42)
-	target_compile_options(bx PUBLIC -msse4.2)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64|i[3-6]86|x86)$")
+	target_compile_options(bx PUBLIC $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-msse4.2>)
 endif()
 
 # Link against psapi on Windows


### PR DESCRIPTION
Last commit cf47cdd6b2dd1b45d19450b2b4c3a2267b6a9e87 introduced a warning on macOS ARM64:

```
Warning: argument unused during compilation: '-msse4.2'
```

The problem: on macOS ARM64 (Apple Silicon), Apple Clang accepts `-msse4.2` syntactically (so `check_cxx_compiler_flag` returns true), but then warns `argument unused during compilation` because SSE is not applicable on ARM, and you have `-Werror`.

This fix replaces the `check_cxx_compiler_flag` block with a block that reflects the intent of [toolchain.lua](https://github.com/bkaradzic/bx/blob/master/scripts/toolchain.lua).
