### PR TITLE
Add NO_SOURCE_GROUP option and make source_group optional in bgfx_compile_shaders

### DIFF
--- a/cmake/bgfxToolUtils.cmake
+++ b/cmake/bgfxToolUtils.cmake
@@ -567,10 +567,11 @@ if(TARGET bgfx::shaderc)
 	# 	DEFINES defines
 	# 	[PROFILES profiles]
 	# 	[AS_HEADERS]
+	# 	[NO_SOURCE_GROUP]
 	# )
 	#
 	function(bgfx_compile_shaders)
-		set(options AS_HEADERS)
+		set(options AS_HEADERS NO_SOURCE_GROUP)
 		set(oneValueArgs TYPE VARYING_DEF OUTPUT_DIR OUT_FILES_VAR)
 		set(multiValueArgs SHADERS INCLUDE_DIRS DEFINES PROFILES)
 		cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
@@ -627,7 +628,9 @@ if(TARGET bgfx::shaderc)
 
 		set(ALL_OUTPUTS "")
 		foreach(SHADER_FILE ${ARGS_SHADERS})
-			source_group("Shaders" FILES "${SHADER}")
+			if(NOT ARGS_NO_SOURCE_GROUP)
+				source_group("Shaders" FILES "${SHADER_FILE}")
+			endif()
 			get_filename_component(SHADER_FILE_BASENAME ${SHADER_FILE} NAME)
 			get_filename_component(SHADER_FILE_NAME_WE ${SHADER_FILE} NAME_WE)
 			get_filename_component(SHADER_FILE_ABSOLUTE ${SHADER_FILE} ABSOLUTE)


### PR DESCRIPTION
`bgfx_compile_shaders` unconditionally called `source_group("Shaders" FILES ...)` for every shader file, placing all shaders flat under a single "Shaders" IDE folder. This makes it impossible for callers to use `source_group(TREE ...)` to mirror the on-disk directory structure in the IDE project, because the flat group assignment cannot be overridden afterwards.

This PR adds an optional boolean flag `NO_SOURCE_GROUP` to `bgfx_compile_shaders`. When the flag is present the function skips its own `source_group` call entirely, leaving the caller free to organize the source files however they prefer, typically with a `source_group(TREE ...)` call after `bgfx_compile_shaders` returns.

As a secondary fix, the original call was passing the undefined variable `${SHADER}` instead of the loop variable `${SHADER_FILE}`; this is corrected in the same change.