### PR TITLE
fix dx11 example dir (now dxbc)

### DIFF
--- a/cmake/bgfx/examples.cmake
+++ b/cmake/bgfx/examples.cmake
@@ -36,7 +36,7 @@ function(add_bgfx_shader FILE FOLDER)
 
 		if(WIN32)
 			# dx11
-			set(DX11_OUTPUT ${BGFX_DIR}/examples/runtime/shaders/dx11/${FILENAME}.bin)
+			set(DX11_OUTPUT ${BGFX_DIR}/examples/runtime/shaders/dxbc/${FILENAME}.bin)
 			if(NOT "${TYPE}" STREQUAL "COMPUTE")
 				_bgfx_shaderc_parse(
 					DX11 ${COMMON} WINDOWS


### PR DESCRIPTION
for dx11, the configuration copies the shader binaries from runtime/shaders/dxbc to build/shaders directory, but the shaders were still built in runtime/shaders/dx11. 
Therefore in the build directory were copied old shader binaries instead of the newly compiled ones.
This fixes the problem.