### PR TITLE
WebGPU: link Emscripten target against Dawn's emdawnwebgpu port

### DIFF
--- a/cmake/bgfx/bgfx.cmake
+++ b/cmake/bgfx/bgfx.cmake
@@ -53,7 +53,14 @@ endif()
 if(BGFX_CONFIG_RENDERER_WEBGPU)
 	include(${CMAKE_CURRENT_LIST_DIR}/3rdparty/webgpu.cmake)
 	if(EMSCRIPTEN)
-		target_link_options(bgfx PRIVATE "-s USE_WEBGPU=1")
+		# Emscripten's built-in WebGPU bindings (-sUSE_WEBGPU) are deprecated and
+		# expose an outdated webgpu.h that lacks the Dawn C API the current
+		# renderer_webgpu.cpp targets (wgpuInstanceWaitAny, wgpuAdapterRequestDevice,
+		# ...), so linking fails with undefined wgpu* symbols. Use Dawn's maintained
+		# emdawnwebgpu port instead. PUBLIC (not PRIVATE) so the port reaches the
+		# final link of executables that link bgfx -- a link option on a static
+		# archive otherwise never propagates to the consumer.
+		target_link_options(bgfx PUBLIC "--use-port=emdawnwebgpu")
 	else()
 		target_link_libraries(bgfx PRIVATE webgpu)
 	endif()


### PR DESCRIPTION
### Problem

When building the WebGPU renderer for Emscripten (`BGFX_CONFIG_RENDERER_WEBGPU` + emscripten), the CMake wires:

```cmake
if(EMSCRIPTEN)
    target_link_options(bgfx PRIVATE "-s USE_WEBGPU=1")
```

This is broken two ways for the current `renderer_webgpu.cpp`:

1. **`-sUSE_WEBGPU` is deprecated** and provides Emscripten's built-in WebGPU bindings, whose `webgpu.h` predates the Dawn C API the renderer now targets. Linking an Emscripten app therefore fails with undefined symbols — `wgpuInstanceWaitAny`, `wgpuAdapterRequestDevice`, and the rest of the `wgpu*` surface.
2. **`PRIVATE` on the static `bgfx` archive** means even that flag never reaches the final executable link, so consumers linking `bgfx` don't get it regardless.

### Fix

Use Dawn's maintained [`emdawnwebgpu`](https://dawn.googlesource.com/dawn/+/refs/heads/main/src/emdawnwebgpu/) port, which implements the Dawn C `webgpu.h` the renderer calls, and emit it `PUBLIC` so it propagates to the final link of executables that link `bgfx`.

```cmake
target_link_options(bgfx PUBLIC "--use-port=emdawnwebgpu")
```

### Validation

Verified in a downstream Emscripten build: with `--use-port=emdawnwebgpu` on the link, all previously-undefined `wgpu*` symbols resolve and a real bgfx app builds, links, and runs on WebGPU in Chrome (device init + frame loop). WebGPU's async device init additionally needs `-sJSPI=1` (or `-sASYNCIFY`) at the app link — that is an application-level choice, so it is intentionally left out of this change.

This is complementary to (and independent of) #17, which touches the bundled `webgpu.cmake` include dirs rather than the link option.