### PR TITLE
bx: apply the SSE4.2 minspec to every x86 target that needs it

### DIFF
--- a/cmake/bx/bx.cmake
+++ b/cmake/bx/bx.cmake
@@ -100,7 +100,13 @@ target_compile_features(bx PUBLIC cxx_std_14)
 target_compile_options(bx PUBLIC $<$<CXX_COMPILER_ID:MSVC>:/Zc:__cplusplus /Zc:preprocessor>)
 
 # bx/include/bx/simd_t.h includes smmintrin.h unconditionally, so x86/x64 builds need SSE4.2.
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64|i[3-6]86|x86)$" OR
+if(APPLE)
+	# Apple builds may be universal (e.g. arm64;x86_64 compiled in a single invocation), which sets
+	# CMAKE_SYSTEM_PROCESSOR to the arm64 host and hides the x86_64 slice from the processor match
+	# below. Scope the flag to that slice with -Xarch_x86_64 (a no-op when no x86_64 slice is built)
+	# so the arm64 NEON path is left untouched.
+	target_compile_options(bx PUBLIC $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:SHELL:-Xarch_x86_64 -msse4.2>)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64|i[3-6]86|x86)$" OR
 	CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "^(x86_64|amd64|AMD64|i[3-6]86|x86)$")
 	target_compile_options(bx PUBLIC $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-msse4.2>)
 endif()

--- a/cmake/bx/bx.cmake
+++ b/cmake/bx/bx.cmake
@@ -99,11 +99,67 @@ target_compile_features(bx PUBLIC cxx_std_14)
 # (note: see bx\scripts\toolchain.lua for equivalent compiler flag)
 target_compile_options(bx PUBLIC $<$<CXX_COMPILER_ID:MSVC>:/Zc:__cplusplus /Zc:preprocessor>)
 
-# bx/include/bx/simd_t.h includes smmintrin.h unconditionally, so x86/x64 builds need SSE4.2.
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64|i[3-6]86|x86)$" OR
-	CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "^(x86_64|amd64|AMD64|i[3-6]86|x86)$")
-	target_compile_options(bx PUBLIC $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-msse4.2>)
+# bx's SIMD path (bx/inline/simd128_sse.inl) uses SSE4.1 intrinsics on x86, matching the
+# SSE4.2 minspec bx's own scripts/toolchain.lua sets. GCC-style drivers need the flag
+# explicitly or the build fails with "needs target feature sse4.1"; MSVC's cl.exe does not.
+# PUBLIC because bgfx/bimg compile bx's SIMD headers into their own translation units.
+set(BX_X86_ARCH_REGEX "^(x86_64|amd64|AMD64|x64|i[3-6]86|x86)$")
+
+if(APPLE)
+	# Apple builds can be universal and CMAKE_SYSTEM_PROCESSOR names only one slice (it is
+	# aarch64 for ios-cmake's SIMULATOR64COMBINED, which also builds x86_64), so the slice
+	# list has to come from CMAKE_OSX_ARCHITECTURES.
+	set(BX_TARGET_ARCHS ${CMAKE_OSX_ARCHITECTURES})
+	if(NOT BX_TARGET_ARCHS)
+		set(BX_TARGET_ARCHS ${CMAKE_SYSTEM_PROCESSOR})
+	endif()
+
+	set(BX_X86_ARCHS ${BX_TARGET_ARCHS})
+	list(FILTER BX_X86_ARCHS INCLUDE REGEX "${BX_X86_ARCH_REGEX}")
+	list(LENGTH BX_TARGET_ARCHS BX_TARGET_ARCH_COUNT)
+
+	if(NOT BX_X86_ARCHS)
+		# Nothing to do. An -Xarch_ flag matching no slice is an unused argument, which is
+		# fatal for consumers building with -Werror.
+	elseif(BX_TARGET_ARCH_COUNT EQUAL 1)
+		target_compile_options(bx PUBLIC "$<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-msse4.2>")
+	else()
+		# -Xarch_ scopes the minspec to the x86 slices so arm64 keeps bx's NEON path.
+		# -Wno-unused-command-line-argument is required because one invocation need not cover
+		# every slice: Xcode compiles per slice, and ios-cmake's COMBINED platforms narrow the
+		# slice list further per SDK.
+		set(BX_SSE_MINSPEC "")
+		foreach(BX_X86_ARCH IN LISTS BX_X86_ARCHS)
+			list(APPEND BX_SSE_MINSPEC "-Xarch_${BX_X86_ARCH}" "-msse4.2")
+		endforeach()
+		list(APPEND BX_SSE_MINSPEC "-Wno-unused-command-line-argument")
+		list(JOIN BX_SSE_MINSPEC " " BX_SSE_MINSPEC)
+		target_compile_options(bx PUBLIC "$<$<NOT:$<CXX_COMPILER_ID:MSVC>>:SHELL:${BX_SSE_MINSPEC}>")
+		unset(BX_SSE_MINSPEC)
+	endif()
+
+	unset(BX_TARGET_ARCH_COUNT)
+	unset(BX_X86_ARCHS)
+	unset(BX_TARGET_ARCHS)
+elseif(NOT EMSCRIPTEN)
+	# CMAKE_CXX_COMPILER_ARCHITECTURE_ID is the target arch where the compiler reports it
+	# (MSVC/clang-cl); CMAKE_SYSTEM_PROCESSOR reports the host on Windows but is the target
+	# elsewhere (the Android NDK sets i686 for the x86 ABI). Emscripten reports x86 yet builds
+	# bx's wasm path, and emcc rejects -msse4.2 without -msimd128.
+	if(CMAKE_CXX_COMPILER_ARCHITECTURE_ID)
+		set(BX_TARGET_ARCH "${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}")
+	else()
+		set(BX_TARGET_ARCH "${CMAKE_SYSTEM_PROCESSOR}")
+	endif()
+
+	if(BX_TARGET_ARCH MATCHES "${BX_X86_ARCH_REGEX}")
+		target_compile_options(bx PUBLIC "$<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-msse4.2>")
+	endif()
+
+	unset(BX_TARGET_ARCH)
 endif()
+
+unset(BX_X86_ARCH_REGEX)
 
 # Link against psapi on Windows
 if(WIN32)


### PR DESCRIPTION
## Problem

The SSE4.2 guard for `bx` keys off `CMAKE_SYSTEM_PROCESSOR` / `CMAKE_CXX_COMPILER_ARCHITECTURE_ID`:

```cmake
# bx/include/bx/simd_t.h includes smmintrin.h unconditionally, so x86/x64 builds need SSE4.2.
if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64|i[3-6]86|x86)$" OR
	CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "^(x86_64|amd64|AMD64|i[3-6]86|x86)$")
	target_compile_options(bx PUBLIC $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-msse4.2>)
endif()
```

That is right for single-architecture builds, but **Apple builds compile several slices from a
single configure while `CMAKE_SYSTEM_PROCESSOR` describes only one of them**:

- `CMAKE_OSX_ARCHITECTURES="arm64;x86_64"` on an Apple Silicon host → `CMAKE_SYSTEM_PROCESSOR` is `arm64`.
- leetal/ios-cmake `SIMULATOR64COMBINED` (`ARCHS = "arm64 x86_64"`) → the toolchain sets `CMAKE_SYSTEM_PROCESSOR` to `aarch64`; the legacy i386 simulator sets it to `arm`.

In each case the guard is false, so the **x86_64 slice** builds without the minspec and fails on
bx's SIMD path:

```
simd128_sse.inl:296:10: error: '__builtin_ia32_roundps' needs target feature sse4.1
simd128_sse.inl:769:10: error: always_inline function '_mm_blendv_ps' requires target
                               feature 'sse4.1', but would be inlined into function
                               'simd128_selb' that is compiled without support for 'sse4.1'
```

## Change

**Apple** — derive the slice list from `CMAKE_OSX_ARCHITECTURES` (falling back to
`CMAKE_SYSTEM_PROCESSOR` when it is unset) and emit an `-Xarch_<arch>` pair for every x86 slice of
a universal build, so the arm64 slice keeps bx's NEON path. Single-slice builds get a plain
`-msse4.2`, and builds with no x86 slice get nothing at all.

**Non-Apple** — same architecture sources, but `CMAKE_CXX_COMPILER_ARCHITECTURE_ID` is now
*preferred* rather than OR-ed with `CMAKE_SYSTEM_PROCESSOR`. On Windows `CMAKE_SYSTEM_PROCESSOR`
reports the **host**, so the OR form handed `-msse4.2` to clang-cl cross-builds targeting ARM64.
Emscripten is excluded: it reports `CMAKE_SYSTEM_PROCESSOR` as `x86`, but bx takes its wasm SIMD
path there (`BX_CPU_X86` is 0) and `emcc` rejects `-msse4.2` without `-msimd128`.

### Answers to the two questions this raises

**Why `-Wno-unused-command-line-argument`?** Because a single compiler invocation does not
necessarily cover every slice. The Xcode generator runs the compiler once per slice, and
ios-cmake's `COMBINED` platforms narrow the slice list further per SDK — `OS64COMBINED` sets
`ARCHS[sdk=iphoneos*] = "arm64"`, so the device build compiles only arm64 while
`CMAKE_OSX_ARCHITECTURES` still lists `x86_64`. clang then sees an `-Xarch_x86_64` that applies to
nothing and reports it as an unused argument, which is fatal for projects building with `-Werror`
(this is how it surfaced for us). It is scoped to the universal branch only — single-slice builds
never get it.

**Why not just widen the regex?** `-Xarch_` is the only mechanism that works for both generator
families: Ninja/Makefiles pass every `-arch` in one invocation, so an unscoped `-msse4.2` would
land on the arm64 slice too.

## Verification

**1. The failure and the fix reproduce directly.** Compiling the two SSE4.1 code paths at an SSE2
baseline:

```
$ clang++ -m32 -msse2   -std=c++20 -DBX_CONFIG_DEBUG=0 -c -I bx/include simdtest.cpp
simd128_sse.inl:296:10: error: '__builtin_ia32_roundps' needs target feature sse4.1
simd128_sse.inl:769:10: error: always_inline function '_mm_blendv_ps' requires target feature 'sse4.1'
2 errors generated.                                                        # exit 1

$ clang++ -m32 -msse4.2 -std=c++20 -DBX_CONFIG_DEBUG=0 -c -I bx/include simdtest.cpp
                                                                           # exit 0
```

**2. Resulting flags across 25 configurations**, driven through the real block with the platform
variables each toolchain sets (❌ marks what was broken before this PR):

| configuration | flags added to `bx` (PUBLIC) |
| --- | --- |
| **macOS universal (`arm64;x86_64`)** | **`-Xarch_x86_64 -msse4.2 -Wno-unused-command-line-argument`** ❌ |
| macOS `x86_64` only | `-msse4.2` |
| macOS `arm64` only | *(none)* |
| macOS, no `CMAKE_OSX_ARCHITECTURES`, x86_64 host | `-msse4.2` |
| **macOS 3-slice (`x86_64;arm64;arm64e`)** | **`-Xarch_x86_64 -msse4.2 -Wno-unused-command-line-argument`** ❌ |
| iOS `OS64` (device arm64) | *(none)* |
| **iOS `OS64COMBINED`** | **`-Xarch_x86_64 -msse4.2 -Wno-unused-command-line-argument`** ❌ |
| iOS `SIMULATOR64` (x86_64) | `-msse4.2` |
| **iOS `SIMULATOR64COMBINED`** | **`-Xarch_x86_64 -msse4.2 -Wno-unused-command-line-argument`** ❌ |
| iOS `SIMULATORARM64` | *(none)* |
| **iOS `SIMULATOR` (legacy i386)** | **`-msse4.2`** ❌ |
| **watchOS `WATCHOSCOMBINED` (`armv7k;arm64_32;x86_64`)** | **`-Xarch_x86_64 -msse4.2 -Wno-unused-command-line-argument`** ❌ |
| Android `x86` (i686) | `-msse4.2` |
| Android `x86_64` | `-msse4.2` |
| Android `armeabi-v7a` / `arm64-v8a` | *(none)* |
| Linux `x86_64` / `i686` (gcc) | `-msse4.2` |
| Linux `aarch64` (gcc) | *(none)* |
| Windows MSVC x64 / ARM64 / Win32 | *(none)* — `cl.exe` needs no ISA switch |
| Windows clang (GNU driver) x64 | `-msse4.2` |
| **Windows clang-cl → ARM64 (x64 host)** | ***(none)*** ❌ |
| Emscripten (wasm) | *(none)* |

**3. Propagation.** Confirmed via `compile_commands.json` that the `SHELL:` generator expression
expands to separate tokens and reaches downstream consumers, i.e. the `bimg` target whose
`image.cpp` is what failed for us:

```
bx.cpp    -Xarch_x86_64 -msse4.2 -Wno-unused-command-line-argument
bimg.cpp  -Xarch_x86_64 -msse4.2 -Wno-unused-command-line-argument
```

**4. Build + formatting.** `bx` configures and builds cleanly with MSVC (no `-msse4.2` leaks into
the MSVC project), and the file now passes
`cmake-format --config-files .cmake-format.py --check` with the `cmakelang==0.6.13` version pinned
by the Format workflow — the previous multi-line `if(... OR ...)` did not.
