### PR TITLE
Fix Format workflow failing on fork PRs

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,7 +4,7 @@ name: Format
 on:
   push:
     branches: [ master ]
-  pull_request_target:
+  pull_request:
     branches: [ master ]
 
 jobs:
@@ -12,13 +12,7 @@ jobs:
     name: cmake-format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Add base repo to git config
-        run: git remote add upstream ${{ github.event.pull_request.base.repo.html_url }}
-        if: startsWith(github.event_name, 'pull_request')
+      - uses: actions/checkout@v7
       - name: Format CMake files
         id: cmake-format
         uses: PuneetMatharu/cmake-format-lint-action@v1.0.6
@@ -31,13 +25,7 @@ jobs:
     needs: cmake-format-check
     if: always() && startsWith(github.event_name, 'pull_request') && needs.cmake-format-check.result == 'failure'
     steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Add base repo to git config
-        run: git remote add upstream ${{ github.event.pull_request.base.repo.html_url }}
-        if: startsWith(github.event_name, 'pull_request')
+      - uses: actions/checkout@v7
       - name: Format CMake files
         id: cmake-format
         uses: PuneetMatharu/cmake-format-lint-action@v1.0.6


### PR DESCRIPTION
GitHub recently changed `actions/checkout` so it refuses to check out code from a fork when the workflow runs on `pull_request_target`. Because of this, the Format check now fails on every PR from a fork (see the error in recent PR runs).

This change switches the workflow to the normal `pull_request` trigger, which doesn't have this restriction. With that, the custom checkout settings and the extra `git remote` steps aren't needed anymore, so they're removed. Also bumps checkout to v7.

What still works:
- The cmake-format check runs on every PR, same as before
- If formatting is wrong, the fix is uploaded as a downloadable patch file
- reviewdog still posts formatting suggestions — on fork PRs it falls back to annotations instead of inline suggestions, since fork PRs only get a read-only token