### PR TITLE
Add 53-sky2 and 54-s2h to the example targets.

### DIFF
--- a/cmake/bgfx/examples.cmake
+++ b/cmake/bgfx/examples.cmake
@@ -28,7 +28,12 @@ function(add_bgfx_shader FILE FOLDER)
 	endif()
 
 	if(NOT "${TYPE}" STREQUAL "")
-		set(COMMON FILE ${FILE} ${TYPE} INCLUDES ${BGFX_DIR}/src)
+		set(COMMON FILE ${FILE} ${TYPE} INCLUDES ${BGFX_DIR}/src ${BGFX_DIR}/examples/common)
+		set(SHADER_DEPENDENCIES)
+		if("${FOLDER}" STREQUAL "54-s2h")
+			file(GLOB S2H_SHADER_HEADERS CONFIGURE_DEPENDS ${BGFX_DIR}/examples/common/s2h*)
+			list(APPEND SHADER_DEPENDENCIES ${S2H_SHADER_HEADERS})
+		endif()
 		set(OUTPUTS "")
 		set(OUTPUTS_PRETTY "")
 		set(OUTPUT_FILES "")
@@ -54,6 +59,26 @@ function(add_bgfx_shader FILE FOLDER)
 			endif()
 			list(APPEND OUTPUTS "DX11")
 			set(OUTPUTS_PRETTY "${OUTPUTS_PRETTY}DX11, ")
+
+			# dx12
+			set(DX12_OUTPUT ${BGFX_DIR}/examples/runtime/shaders/dxil/${FILENAME}.bin)
+			if(NOT "${TYPE}" STREQUAL "COMPUTE")
+				_bgfx_shaderc_parse(
+					DX12 ${COMMON} WINDOWS
+					PROFILE s_6_0
+					O 3
+					OUTPUT ${DX12_OUTPUT}
+				)
+			else()
+				_bgfx_shaderc_parse(
+					DX12 ${COMMON} WINDOWS
+					PROFILE s_6_0
+					O 1
+					OUTPUT ${DX12_OUTPUT}
+				)
+			endif()
+			list(APPEND OUTPUTS "DX12")
+			set(OUTPUTS_PRETTY "${OUTPUTS_PRETTY}DX12, ")
 		endif()
 
 		if(APPLE)
@@ -78,13 +103,11 @@ function(add_bgfx_shader FILE FOLDER)
 		list(APPEND OUTPUTS "GLSL")
 		set(OUTPUTS_PRETTY "${OUTPUTS_PRETTY}GLSL, ")
 
-		# spirv
-		if(NOT "${TYPE}" STREQUAL "COMPUTE")
-			set(SPIRV_OUTPUT ${BGFX_DIR}/examples/runtime/shaders/spirv/${FILENAME}.bin)
-			_bgfx_shaderc_parse(SPIRV ${COMMON} LINUX PROFILE spirv OUTPUT ${SPIRV_OUTPUT})
-			list(APPEND OUTPUTS "SPIRV")
-			set(OUTPUTS_PRETTY "${OUTPUTS_PRETTY}SPIRV, ")
-		endif()
+		# spirv (required by Vulkan for every shader stage, including compute)
+		set(SPIRV_OUTPUT ${BGFX_DIR}/examples/runtime/shaders/spirv/${FILENAME}.bin)
+		_bgfx_shaderc_parse(SPIRV ${COMMON} LINUX PROFILE spirv OUTPUT ${SPIRV_OUTPUT})
+		list(APPEND OUTPUTS "SPIRV")
+		set(OUTPUTS_PRETTY "${OUTPUTS_PRETTY}SPIRV, ")
 
 		# wgsl
 		set(WGSL_OUTPUT ${BGFX_DIR}/examples/runtime/shaders/wgsl/${FILENAME}.bin)
@@ -101,7 +124,7 @@ function(add_bgfx_shader FILE FOLDER)
 
 		file(RELATIVE_PATH PRINT_NAME ${BGFX_DIR}/examples ${FILE})
 		add_custom_command(
-			MAIN_DEPENDENCY ${FILE} OUTPUT ${OUTPUT_FILES} ${COMMANDS}
+			MAIN_DEPENDENCY ${FILE} DEPENDS ${SHADER_DEPENDENCIES} OUTPUT ${OUTPUT_FILES} ${COMMANDS}
 			COMMENT "Compiling shader ${PRINT_NAME} for ${OUTPUTS_PRETTY}"
 		)
 	endif()
@@ -120,9 +143,9 @@ function(add_example ARG_NAME)
 			file(GLOB GLOB_SOURCES ${DIR}/*.mm)
 			list(APPEND SOURCES ${GLOB_SOURCES})
 		endif()
-		file(GLOB GLOB_SOURCES ${DIR}/*.c ${DIR}/*.cpp ${DIR}/*.h ${DIR}/*.sc)
+		file(GLOB GLOB_SOURCES CONFIGURE_DEPENDS ${DIR}/*.c ${DIR}/*.cpp ${DIR}/*.h ${DIR}/*.sc)
 		list(APPEND SOURCES ${GLOB_SOURCES})
-		file(GLOB GLOB_SHADERS ${DIR}/*.sc)
+		file(GLOB GLOB_SHADERS CONFIGURE_DEPENDS ${DIR}/*.sc)
 		list(APPEND SHADERS ${GLOB_SHADERS})
 	endforeach()
 
@@ -347,6 +370,8 @@ if(BGFX_BUILD_EXAMPLES)
 		50-headless
 		51-gpufont
 		52-layered
+		53-sky2
+		54-s2h
 	)
 
 	foreach(EXAMPLE ${BGFX_EXAMPLES})


### PR DESCRIPTION
Compile DXIL shaders for DX12 and SPIR-V compute shaders for Vulkan.
Add the common shader include directory and track S2H shared headers so changes rebuild the example shaders automatically.
Use CONFIGURE_DEPENDS when discovering example sources and shaders.

deps: bump bgfx to the latest