### PR TITLE
Specify video_mtl.cpp as objective-c++

### DIFF
--- a/cmake/bgfx/bgfx.cmake
+++ b/cmake/bgfx/bgfx.cmake
@@ -205,6 +205,7 @@ if(XCODE)
 	set_source_files_properties(
 		${BGFX_DIR}/src/renderer_vk.cpp
 		${BGFX_DIR}/src/renderer_webgpu.cpp
+		${BGFX_DIR}/src/video_mtl.cpp
 		PROPERTIES
 			LANGUAGE OBJCXX
 			XCODE_EXPLICIT_FILE_TYPE sourcecode.cpp.objcpp


### PR DESCRIPTION
## Problem
video_mtl.cpp fails to compile in XCode, needs to be specified as objective-c++.

## Change
added to `bgfx.cmake`:
```
set_source_files_properties(
		${BGFX_DIR}/src/video_mtl.cpp
		PROPERTIES
			LANGUAGE OBJCXX
			XCODE_EXPLICIT_FILE_TYPE sourcecode.cpp.objcpp
```